### PR TITLE
Fix bug regarding user creation

### DIFF
--- a/script/create_user.py
+++ b/script/create_user.py
@@ -1,7 +1,7 @@
 import airflow
 from airflow import models, settings
 from airflow.contrib.auth.backends.password_auth import PasswordUser
-import sys
+import os
 
 # Creates a user to login into the Airflow UI
 # Uses command line arguments to configure the user:
@@ -9,8 +9,8 @@ import sys
 #   2nd arg: password
 
 user = PasswordUser(models.User())
-user.username = sys.argv[1]
-user.password = sys.argv[2]
+user.username = os.getenv("AUTHENTICATION_USERNAME")
+user.password = os.getenv("AUTHENTICATION_PASSWORD")
 user.superuser = True
 session = settings.Session()
 session.add(user)

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -93,7 +93,7 @@ fi
 case "$1" in
   webserver)
     airflow initdb
-    python /create_user.py $AUTHENTICATION_USERNAME $AUTHENTICATION_PASSWORD
+    python /create_user.py
     if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
       # With the "Local" executor it should all run in one container.
       airflow scheduler &


### PR DESCRIPTION
In previous implementation user was created with wrong username or password if either of them contained spaces. This commit
changes the create_user.py script to use the environment variables directly instead of passing the variables to the script as arguments.